### PR TITLE
[FIX][FernuniMigration - i9202] Using the sales payment_term instead …

### DIFF
--- a/l10n_ch_scan_bvr/wizard/scan_bvr.py
+++ b/l10n_ch_scan_bvr/wizard/scan_bvr.py
@@ -199,8 +199,11 @@ class ScanBvr(models.TransientModel):
             [('name', '=', data['bvr_struct']['currency'])])
         date_due = today
         # We will now compute the due date and fixe the payment term
+        # Hack esal1: v6.1 for Fernuni used the payment_term of sales
+        # payment_term_id = (account_info.partner_id.
+        #                    property_supplier_payment_term_id.id)
         payment_term_id = (account_info.partner_id.
-                           property_supplier_payment_term_id.id)
+                           property_payment_term_id.id)
         if payment_term_id:
             # We Calculate @due_date
             with self.env.do_in_onchange():


### PR DESCRIPTION
…of the one used for purchases (standard in v9.0) for scan BVR.