### PR TITLE
[i11585] [Bug] l10n_ch_lsv_dd - invoice total_amount is taken instead of residual

### DIFF
--- a/l10n_ch_lsv_dd/model/invoice.py
+++ b/l10n_ch_lsv_dd/model/invoice.py
@@ -314,7 +314,7 @@ class AccountInvoice(models.Model):
                     'communication': communication_text,
                     'state': 'normal',
                     'mandate_id': banking_mandate_id.id,
-                    'amount_currency': invoice.amount_total,
+                    'amount_currency': invoice.residual,
                     'currency': invoice.currency_id.id,
                     'company_currency': company_currency.id,
                     'company_id': company.id,


### PR DESCRIPTION
i11585  l10n_ch_lsv_dd - creates payment_orderand and lsv/dd file with invoice.residual instead of invoice.amount_total