### PR TITLE
7.0_correct_mako_if_no_invoice_assigned_in_payment_line

### DIFF
--- a/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
+++ b/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
@@ -22,7 +22,7 @@
    line=sepa_context['line']
    invoice = line.move_line_id.invoice
    %>
-   % if not invoice.partner_bank_id.state == 'bvr':
+   % if not (invoice and invoice.partner_bank_id and invoice.partner_bank_id.state == 'bvr'):
     ${parent.CdtrAgt()}
    % endif
 </%block>
@@ -47,7 +47,7 @@
    line=sepa_context['line']
    invoice = line.move_line_id.invoice
    %>
-   % if invoice.partner_bank_id.state == 'bvr':
+   % if invoice and invoice.partner_bank_id and invoice.partner_bank_id.state == 'bvr':
           <PmtTpInf>
               <LclInstrm>
                 <Prtry>CH01</Prtry>


### PR DESCRIPTION
In Payment Order Line it is not mandatory to have move line assigned.