### PR TITLE
bt1739_pain001_adapt_to_xsd

### DIFF
--- a/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
+++ b/l10n_ch_sepa/base_sepa/base_template/pain.001.001.03.xml.mako
@@ -78,7 +78,8 @@
         <ReqdExctnDt>${line.date > today and line.date or today}</ReqdExctnDt>
         <Dbtr>
           <Nm>${order.user_id.company_id.name | filter_text}</Nm>\
-          ${self.address(order.user_id.company_id.partner_id) | filter_text}\
+            <!-- SIX ISO20022 Recommendation: Do not use. -->
+            <!--${self.address(order.user_id.company_id.partner_id) | filter_text}\-->
         </Dbtr>
         <DbtrAcct>\
           ${self.acc_id(order.mode.bank_id)}\
@@ -90,6 +91,7 @@
         </DbtrAgt>
         <CdtTrfTxInf>
           <PmtId>
+            <InstrId>${line.name}</InstrId>
             <EndToEndId>${line.name}</EndToEndId>
           </PmtId>
           <% sepa_context['line'] = line %>
@@ -130,6 +132,9 @@
               <PstlAdr>
                 %if partner.street:
                   <StrtNm>${partner.street | filter_text}</StrtNm>
+                %endif
+                %if partner.street_no:
+                  <BldgNb>${partner.street_no | filter_text}</BldgNb>
                 %endif
                 %if partner.zip:
                   <PstCd>${partner.zip | filter_text}</PstCd>

--- a/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
+++ b/l10n_ch_sepa/l10n_ch/template/pain.001.001.03.ch.02.xml.mako
@@ -21,8 +21,9 @@
    <%
    line=sepa_context['line']
    invoice = line.move_line_id.invoice
+   bank = invoice.partner_bank_id or (invoice.partner_id.bank_ids and invoice.partner_id.bank_ids[0]) or (invoice.partner_id.parent_id and invoice.partner_id.parent_id.bank_ids and invoice.partner_id.parent_id.bank_ids[0])
    %>
-   % if not invoice.partner_bank_id.state == 'bvr':
+   % if not (bank.state == 'bvr' or bank.state == 'bv'):
     ${parent.CdtrAgt()}
    % endif
 </%block>
@@ -58,13 +59,6 @@
           <PmtTpInf>
               <LclInstrm>
                 <Prtry>CH02</Prtry>
-              </LclInstrm>
-          </PmtTpInf>
-   % elif bank.state in ('iban', 'bank'):
-          <PmtTpInf>
-              <LclInstrm>
-                <Prtry>CH03</Prtry>
-                  <% bank.state %>
               </LclInstrm>
           </PmtTpInf>
    % endif


### PR DESCRIPTION
- In case of payment method ESR (ISO: CH01)(Odoo: bank.type = 'bvr') or  ES (ISO: CH02)(Odoo: bank.type = 'bv') CdtrAgt must not been included in pain.001 file
- In case of any other payment method CdtrAgt should be included

- PstlAdr: is recomended not to be uses in PmtInf/Dbtr
- InstrId: Recommendation: Should be used and be unique within the B Level.
- BldgNb: Recommendation: Use. If structured address format it should be used!