### PR TITLE
[t117599] QR Bill: Installation Basic-Package

### DIFF
--- a/l10n_ch_payment_slip/controllers/web.py
+++ b/l10n_ch_payment_slip/controllers/web.py
@@ -10,7 +10,8 @@ from odoo.http import content_disposition, request, route
 class ReportController(report.ReportController):
     @route()
     def report_routes(self, reportname, docids=None, converter=None, **data):
-        if converter == "reportlab-pdf":
+        if converter == "reportlab-pdf" and \
+                reportname == "l10n_ch_payment_slip.one_slip_per_page_from_invoice":
             report_slip = request.env.ref(
                 'l10n_ch_payment_slip.one_slip_per_page_from_invoice')
             filename = ''


### PR DESCRIPTION
report_routes in other modules not called if converter is reportlab-pdf

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=117599">[t117599] QR Bill: Installation Basic-Package</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>l10n_ch_payment_slip</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->