### PR TITLE
[bt#27509][FIX] remove bic check, not needed

### DIFF
--- a/l10n_ch_pain_base/models/account_payment_order.py
+++ b/l10n_ch_pain_base/models/account_payment_order.py
@@ -79,7 +79,7 @@ class AccountPaymentOrder(models.Model):
             if bank_line.payment_line_ids[:1].local_instrument == "CH01":
                 # Don't set the creditor agent on ISR/CH01 payments
                 return True
-            elif not partner_bank.bank_bic:
+            elif partner_bank.acc_type != 'iban' and not partner_bank.bank_bic:
                 raise UserError(
                     _(
                         "For pain.001.001.03.ch.02, for non-ISR payments, "


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=27509">[bt#27509] Online Shop: Filters for Manufacturer and Unit of Measure</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>l10n_ch_pain_base</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->